### PR TITLE
fix: disable OAuth2 filter on the 421 fallback virtual host

### DIFF
--- a/internal/xds/resbuilder/interfaces/interfaces.go
+++ b/internal/xds/resbuilder/interfaces/interfaces.go
@@ -31,7 +31,8 @@ type FilterChainBuilder interface {
 // RoutingBuilder is responsible for building routing configuration
 type RoutingBuilder interface {
 	BuildRouteConfiguration(vs *v1alpha1.VirtualService, xdsListener *listenerv3.Listener,
-		nn helpers.NamespacedName) (*routev3.VirtualHost, *routev3.RouteConfiguration, error)
+		nn helpers.NamespacedName, httpFilters []*hcmv3.HttpFilter,
+	) (*routev3.VirtualHost, *routev3.RouteConfiguration, error)
 	BuildVirtualHost(vs *v1alpha1.VirtualService, nn helpers.NamespacedName) (*routev3.VirtualHost, error)
 }
 

--- a/internal/xds/resbuilder/main_builder/builder.go
+++ b/internal/xds/resbuilder/main_builder/builder.go
@@ -294,7 +294,7 @@ func (b *Builder) buildResourcesFromVirtualService(
 	}
 
 	// 2. Build route configuration
-	virtualHost, routeConfig, err := b.routingBuilder.BuildRouteConfiguration(vs, xdsListener, nn)
+	virtualHost, routeConfig, err := b.routingBuilder.BuildRouteConfiguration(vs, xdsListener, nn, httpFilters)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build route configuration: %w", err)
 	}

--- a/internal/xds/resbuilder/main_builder/builder_test.go
+++ b/internal/xds/resbuilder/main_builder/builder_test.go
@@ -68,8 +68,9 @@ func (m *MockRoutingBuilder) BuildRouteConfiguration(
 	vs *v1alpha1.VirtualService,
 	xdsListener *listenerv3.Listener,
 	nn helpers.NamespacedName,
+	httpFilters []*hcmv3.HttpFilter,
 ) (*routev3.VirtualHost, *routev3.RouteConfiguration, error) {
-	args := m.Called(vs, xdsListener, nn)
+	args := m.Called(vs, xdsListener, nn, httpFilters)
 	return args.Get(0).(*routev3.VirtualHost), args.Get(1).(*routev3.RouteConfiguration), args.Error(2)
 }
 

--- a/internal/xds/resbuilder/routes/builder.go
+++ b/internal/xds/resbuilder/routes/builder.go
@@ -5,11 +5,13 @@ import (
 
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	hcmv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/kaasops/envoy-xds-controller/api/v1alpha1"
 	"github.com/kaasops/envoy-xds-controller/internal/helpers"
 	"github.com/kaasops/envoy-xds-controller/internal/protoutil"
 	"github.com/kaasops/envoy-xds-controller/internal/store"
 	"github.com/kaasops/envoy-xds-controller/internal/xds/resbuilder/utils"
+	"google.golang.org/protobuf/types/known/anypb"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -31,6 +33,7 @@ func (b *Builder) BuildRouteConfiguration(
 	vs *v1alpha1.VirtualService,
 	xdsListener *listenerv3.Listener,
 	nn helpers.NamespacedName,
+	httpFilters []*hcmv3.HttpFilter,
 ) (*routev3.VirtualHost, *routev3.RouteConfiguration, error) {
 	virtualHost, err := b.BuildVirtualHost(vs, nn)
 	if err != nil {
@@ -50,7 +53,11 @@ func (b *Builder) BuildRouteConfiguration(
 	// Add fallback virtual host for TLS listeners if needed
 	listenerIsTLS := utils.IsTLSListener(xdsListener)
 	hasPort443 := utils.ListenerHasPort443(xdsListener)
-	b.AddFallbackVirtualHostIfNeeded(routeConfiguration, virtualHost, listenerIsTLS, hasPort443)
+	if err := b.AddFallbackVirtualHostIfNeeded(
+		routeConfiguration, virtualHost, httpFilters, listenerIsTLS, hasPort443,
+	); err != nil {
+		return nil, nil, err
+	}
 
 	return virtualHost, routeConfiguration, nil
 }
@@ -234,7 +241,12 @@ func (b *Builder) moveRouteToEnd(virtualHost *routev3.VirtualHost, index int) {
 
 // BuildFallbackVirtualHost creates a fallback virtual host for TLS listeners
 // This addresses https://github.com/envoyproxy/envoy/issues/37810
-func (b *Builder) BuildFallbackVirtualHost() *routev3.VirtualHost {
+func (b *Builder) BuildFallbackVirtualHost(httpFilters []*hcmv3.HttpFilter) (*routev3.VirtualHost, error) {
+	perFilterConfig, err := buildFallbackPerFilterConfig(httpFilters)
+	if err != nil {
+		return nil, err
+	}
+
 	return &routev3.VirtualHost{
 		Name:    "421vh",
 		Domains: []string{"*"},
@@ -250,23 +262,61 @@ func (b *Builder) BuildFallbackVirtualHost() *routev3.VirtualHost {
 				},
 			},
 		},
+		TypedPerFilterConfig: perFilterConfig,
+	}, nil
+}
+
+// buildFallbackPerFilterConfig disables HTTP filters that would answer the request
+// before the fallback virtual host can return 421.
+// HTTP filters are configured for the whole filter chain, so they also apply to the
+// fallback virtual host: OAuth2 redirects an unauthenticated request to the authorization
+// endpoint, and the client never learns it has to open a new connection.
+// Filter names are user-defined, so they are taken from the actual filter chain
+// instead of being hardcoded.
+func buildFallbackPerFilterConfig(httpFilters []*hcmv3.HttpFilter) (map[string]*anypb.Any, error) {
+	var perFilterConfig map[string]*anypb.Any
+
+	for _, httpFilter := range httpFilters {
+		if httpFilter.GetTypedConfig().GetTypeUrl() != utils.TypeURLOAuth2 {
+			continue
+		}
+
+		disabled, err := anypb.New(&routev3.FilterConfig{Disabled: true})
+		if err != nil {
+			return nil, fmt.Errorf("failed to disable http filter %s: %w", httpFilter.GetName(), err)
+		}
+
+		if perFilterConfig == nil {
+			perFilterConfig = make(map[string]*anypb.Any, 1)
+		}
+		perFilterConfig[httpFilter.GetName()] = disabled
 	}
+
+	return perFilterConfig, nil
 }
 
 // AddFallbackVirtualHostIfNeeded adds a fallback virtual host to route configuration if needed
 func (b *Builder) AddFallbackVirtualHostIfNeeded(
 	routeConfig *routev3.RouteConfiguration,
 	virtualHost *routev3.VirtualHost,
+	httpFilters []*hcmv3.HttpFilter,
 	isTLSListener, hasPort443 bool,
-) {
+) error {
 	// Add fallback route for TLS listeners
 	// https://github.com/envoyproxy/envoy/issues/37810
 	shouldAddFallback := isTLSListener &&
 		!(len(virtualHost.Domains) == 1 && virtualHost.Domains[0] == "*") &&
 		hasPort443
 
-	if shouldAddFallback {
-		fallbackVH := b.BuildFallbackVirtualHost()
-		routeConfig.VirtualHosts = append(routeConfig.VirtualHosts, fallbackVH)
+	if !shouldAddFallback {
+		return nil
 	}
+
+	fallbackVH, err := b.BuildFallbackVirtualHost(httpFilters)
+	if err != nil {
+		return err
+	}
+	routeConfig.VirtualHosts = append(routeConfig.VirtualHosts, fallbackVH)
+
+	return nil
 }

--- a/internal/xds/resbuilder/routes/builder_test.go
+++ b/internal/xds/resbuilder/routes/builder_test.go
@@ -1,0 +1,201 @@
+package routes
+
+import (
+	"testing"
+
+	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	oauth2v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/oauth2/v3"
+	routerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
+	hcmv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+// httpFilter builds an HTTP filter with the given name and typed config,
+// the same shape BuildHTTPFilters produces from VirtualService spec.
+func httpFilter(t *testing.T, name string, cfg proto.Message) *hcmv3.HttpFilter {
+	t.Helper()
+
+	typedConfig, err := anypb.New(cfg)
+	require.NoError(t, err)
+
+	return &hcmv3.HttpFilter{
+		Name:       name,
+		ConfigType: &hcmv3.HttpFilter_TypedConfig{TypedConfig: typedConfig},
+	}
+}
+
+// assertFilterDisabled asserts the per filter config entry disables the filter.
+func assertFilterDisabled(t *testing.T, entry *anypb.Any) {
+	t.Helper()
+
+	require.NotNil(t, entry)
+
+	var filterConfig routev3.FilterConfig
+	require.NoError(t, entry.UnmarshalTo(&filterConfig))
+	assert.True(t, filterConfig.GetDisabled())
+}
+
+func TestBuildFallbackVirtualHost(t *testing.T) {
+	b := NewBuilder(nil)
+
+	t.Run("returns 421 direct response for any domain", func(t *testing.T) {
+		vh, err := b.BuildFallbackVirtualHost(nil)
+		require.NoError(t, err)
+
+		assert.Equal(t, "421vh", vh.GetName())
+		assert.Equal(t, []string{"*"}, vh.GetDomains())
+		require.Len(t, vh.GetRoutes(), 1)
+		assert.Equal(t, "/", vh.GetRoutes()[0].GetMatch().GetPrefix())
+		assert.Equal(t, uint32(421), vh.GetRoutes()[0].GetDirectResponse().GetStatus())
+		assert.NoError(t, vh.ValidateAll())
+	})
+
+	t.Run("keeps per filter config empty without oauth2", func(t *testing.T) {
+		filters := []*hcmv3.HttpFilter{
+			httpFilter(t, "envoy.filters.http.router", &routerv3.Router{}),
+		}
+
+		vh, err := b.BuildFallbackVirtualHost(filters)
+		require.NoError(t, err)
+
+		assert.Nil(t, vh.GetTypedPerFilterConfig())
+	})
+
+	t.Run("disables oauth2 filter", func(t *testing.T) {
+		filters := []*hcmv3.HttpFilter{
+			httpFilter(t, "envoy.filters.http.oauth2", &oauth2v3.OAuth2{}),
+			httpFilter(t, "envoy.filters.http.router", &routerv3.Router{}),
+		}
+
+		vh, err := b.BuildFallbackVirtualHost(filters)
+		require.NoError(t, err)
+
+		perFilterConfig := vh.GetTypedPerFilterConfig()
+		require.Len(t, perFilterConfig, 1)
+		assertFilterDisabled(t, perFilterConfig["envoy.filters.http.oauth2"])
+		assert.NoError(t, vh.ValidateAll())
+	})
+
+	t.Run("disables oauth2 filter under a user defined name", func(t *testing.T) {
+		filters := []*hcmv3.HttpFilter{
+			httpFilter(t, "sso", &oauth2v3.OAuth2{}),
+		}
+
+		vh, err := b.BuildFallbackVirtualHost(filters)
+		require.NoError(t, err)
+
+		perFilterConfig := vh.GetTypedPerFilterConfig()
+		require.Len(t, perFilterConfig, 1)
+		assertFilterDisabled(t, perFilterConfig["sso"])
+	})
+
+	t.Run("disables every oauth2 filter of the chain", func(t *testing.T) {
+		filters := []*hcmv3.HttpFilter{
+			httpFilter(t, "oauth2-internal", &oauth2v3.OAuth2{}),
+			httpFilter(t, "oauth2-external", &oauth2v3.OAuth2{}),
+			httpFilter(t, "envoy.filters.http.router", &routerv3.Router{}),
+		}
+
+		vh, err := b.BuildFallbackVirtualHost(filters)
+		require.NoError(t, err)
+
+		perFilterConfig := vh.GetTypedPerFilterConfig()
+		require.Len(t, perFilterConfig, 2)
+		assertFilterDisabled(t, perFilterConfig["oauth2-internal"])
+		assertFilterDisabled(t, perFilterConfig["oauth2-external"])
+	})
+
+	t.Run("skips filters without typed config", func(t *testing.T) {
+		filters := []*hcmv3.HttpFilter{{Name: "envoy.filters.http.oauth2"}}
+
+		vh, err := b.BuildFallbackVirtualHost(filters)
+		require.NoError(t, err)
+
+		assert.Nil(t, vh.GetTypedPerFilterConfig())
+	})
+}
+
+func TestAddFallbackVirtualHostIfNeeded(t *testing.T) {
+	b := NewBuilder(nil)
+
+	tests := []struct {
+		name          string
+		domains       []string
+		isTLSListener bool
+		hasPort443    bool
+		wantFallback  bool
+	}{
+		{
+			name:          "tls listener on port 443",
+			domains:       []string{"exc.kaasops.io"},
+			isTLSListener: true,
+			hasPort443:    true,
+			wantFallback:  true,
+		},
+		{
+			name:          "plain listener",
+			domains:       []string{"exc.kaasops.io"},
+			isTLSListener: false,
+			hasPort443:    true,
+			wantFallback:  false,
+		},
+		{
+			name:          "tls listener on another port",
+			domains:       []string{"exc.kaasops.io"},
+			isTLSListener: true,
+			hasPort443:    false,
+			wantFallback:  false,
+		},
+		{
+			name:          "virtual host already catches every domain",
+			domains:       []string{"*"},
+			isTLSListener: true,
+			hasPort443:    true,
+			wantFallback:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			virtualHost := &routev3.VirtualHost{Name: "vh", Domains: tt.domains}
+			routeConfig := &routev3.RouteConfiguration{
+				Name:         "default/virtual-service",
+				VirtualHosts: []*routev3.VirtualHost{virtualHost},
+			}
+
+			err := b.AddFallbackVirtualHostIfNeeded(
+				routeConfig, virtualHost, nil, tt.isTLSListener, tt.hasPort443,
+			)
+			require.NoError(t, err)
+
+			if !tt.wantFallback {
+				assert.Len(t, routeConfig.GetVirtualHosts(), 1)
+				return
+			}
+
+			require.Len(t, routeConfig.GetVirtualHosts(), 2)
+			assert.Equal(t, "421vh", routeConfig.GetVirtualHosts()[1].GetName())
+		})
+	}
+
+	t.Run("propagates oauth2 filters to the fallback virtual host", func(t *testing.T) {
+		virtualHost := &routev3.VirtualHost{Name: "vh", Domains: []string{"exc.kaasops.io"}}
+		routeConfig := &routev3.RouteConfiguration{
+			Name:         "default/virtual-service",
+			VirtualHosts: []*routev3.VirtualHost{virtualHost},
+		}
+		filters := []*hcmv3.HttpFilter{
+			httpFilter(t, "envoy.filters.http.oauth2", &oauth2v3.OAuth2{}),
+		}
+
+		require.NoError(t, b.AddFallbackVirtualHostIfNeeded(routeConfig, virtualHost, filters, true, true))
+
+		require.Len(t, routeConfig.GetVirtualHosts(), 2)
+		fallbackVH := routeConfig.GetVirtualHosts()[1]
+		assertFilterDisabled(t, fallbackVH.GetTypedPerFilterConfig()["envoy.filters.http.oauth2"])
+		assert.Nil(t, virtualHost.GetTypedPerFilterConfig())
+	})
+}


### PR DESCRIPTION
## Summary

The `421vh` fallback virtual host (workaround for envoyproxy/envoy#37810) never returns 421
when the VirtualService has an OAuth2 HTTP filter: filters are configured per HCM filter chain,
not per virtual host, so OAuth2 redirects the request to the authorization endpoint before
routing can produce the 421 direct response.

## Fix

`421vh` now carries `typed_per_filter_config[<filter name>] = FilterConfig{disabled: true}`
for every chain filter whose typed config is OAuth2. Filter names are read off the actual
chain (they are user-defined in the VS spec), not hardcoded. Without an OAuth2 filter the map
stays nil and the virtual host is byte-for-byte what it was before. `disabled` on a virtual
host is inherited by its routes and is resolved without a filter factory lookup; the field
exists since at least Envoy v1.26.

## Testing

- Repro on `envoyproxy/envoy:v1.36.2`: foreign Host got 302 before the fix, 421 after;
  own domain still 302 to authorize in both cases — authentication is not weakened.
- End-to-end on kind: the controller pushes the disable (verified via `config_dump`),
  own domain 302 / foreign Host 421.
- `make test`, `make build`, `make manifests generate` clean; new unit tests for the
  `routes` package (had none); `make test-e2e` — 49/49 passed.

Known limitation: ext_authz / RBAC filters (and OAuth2 delivered via ECDS `config_discovery`)
hit the same class of problem and are left for a follow-up.
